### PR TITLE
Hashaam/fixing tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,6 +62,9 @@ jobs:
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
           pip uninstall em -y
+          pip uninstall empy -y
+          pip install empy
+
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,8 +52,6 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
-          pip uninstall em -y
-          pip install empy --user
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install empy package
         run: |
-          pip install empy
+         pip install em
           
           
           
@@ -61,6 +61,7 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
+          pip uninstall em -y
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,6 +20,11 @@ jobs:
           sudo chmod -R 777 /__w/_temp
           sudo chmod -R 777 /__w/_actions
 
+      - name: Update and upgrade
+        run: |
+          sudo apt update -y
+          sudo apt upgrade -y
+
       - name: Check out ubc-subbots/triton
         uses: actions/checkout@v2
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install deps with rosdep
         run: |
-          rosdep update
+          rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
           
       - name: Cache OpenCV

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,18 +2,17 @@ name: ROS2 Build and Test CI
 
 on:
   push:
-    branches: [ master]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     container:
-      image: ./docker/testing/Dockerfile
+      image: hashaam1217/subbots_triton_testing:1.0.0
     steps:
-
       - name: Check out ubc-subbots/triton
         uses: actions/checkout@v2
 
@@ -26,7 +25,6 @@ jobs:
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
-
 
       - name: Cache OpenCV
         id: opencv-cache
@@ -55,10 +53,9 @@ jobs:
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
           pip uninstall em -y
-
           pip install empy --user
-
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test
           colcon test-result --verbose
+

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,8 +24,7 @@ jobs:
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
-          
-          
+             
           
       - name: Cache OpenCV
         id: opencv-cache

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,8 +25,7 @@ jobs:
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
           
-          pip uninstall em
-          pip install empy #Dependency issue
+          
           
       - name: Cache OpenCV
         id: opencv-cache
@@ -54,6 +53,8 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
+          pip uninstall em
+          pip install empy #Dependency issue
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,6 +13,13 @@ jobs:
     container:
       image: hashaam1217/subbots_triton_testing:1.0.1
     steps:
+      - name: Ensure Permissions
+        run: |
+          sudo mkdir -p /__w/_temp
+          sudo mkdir -p /__w/_actions
+          sudo chmod -R 777 /__w/_temp
+          sudo chmod -R 777 /__w/_actions
+
       - name: Check out ubc-subbots/triton
         uses: actions/checkout@v2
 
@@ -43,6 +50,7 @@ jobs:
           touch ./opencv-install/COLCON_IGNORE
 
       - name: Source setup and build then test using colcon
+        shell: bash
         env:
           LD_LIBRARY_PATH: /usr/local/lib/
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,11 +16,6 @@ jobs:
       - name: Check out ubc-subbots/triton
         uses: actions/checkout@v2
 
-      - name: Setup ROS2 distro and system deps
-        uses: ros-tooling/setup-ros@v0.6
-        with:
-          required-ros-distributions: foxy
-
       - name: Install deps with rosdep
         run: |
           rosdep update --include-eol

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install empy package
         run: |
-          pip install empy -y
+          pip install empy
           
           
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,9 +53,9 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
-          sudo pip uninstall em -y
-          sudo pip uninstall empy -y
-          sudo pip install empy
+          pip uninstall em -y
+          
+          pip install empy --user
 
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     container:
-      image: hashaam1217/subbots_triton_testing:1.0.0
+      image: hashaam1217/subbots_triton_testing:1.0.1
     steps:
       - name: Check out ubc-subbots/triton
         uses: actions/checkout@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-20.04
+    container:
+      image: ./docker/testing/Dockerfile
     steps:
 
       - name: Check out ubc-subbots/triton
@@ -17,15 +19,15 @@ jobs:
 
       - name: Setup ROS2 distro and system deps
         uses: ros-tooling/setup-ros@v0.2
-        with: 
+        with:
           required-ros-distributions: foxy
 
       - name: Install deps with rosdep
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
-             
-          
+
+
       - name: Cache OpenCV
         id: opencv-cache
         uses: actions/cache@v2
@@ -35,17 +37,17 @@ jobs:
 
       - name: Install OpenCV
         uses: rayandrews/with-opencv-action@v1
-        with:  
+        with:
           dir: ./opencv-install
           cached: ${{ steps.opencv-cache.outputs.cache-hit }}
           opencv-version: '4.5.3'
-          CMAKE_BUILD_TYPE: RELEASE   
+          CMAKE_BUILD_TYPE: RELEASE
           ENABLE_PRECOMPILED_HEADERS: OFF
-          
+
       - name: Ignore with colcon build
         run: |
           touch ./opencv-install/COLCON_IGNORE
-          
+
       - name: Source setup and build then test using colcon
         env:
           LD_LIBRARY_PATH: /usr/local/lib/
@@ -53,13 +55,10 @@ jobs:
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
           pip uninstall em -y
-          
+
           pip install empy --user
 
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test
           colcon test-result --verbose
-
-
-

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,14 +24,6 @@ jobs:
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
-
-      - name: Uninstall em package
-        run: |
-          pip uninstall em -y
-
-      - name: Install empy package
-        run: |
-         pip install em
           
           
           
@@ -61,9 +53,9 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
-          pip uninstall em -y
-          pip uninstall empy -y
-          pip install empy
+          sudo pip uninstall em -y
+          sudo pip uninstall empy -y
+          sudo pip install empy
 
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
+          
+          pip uninstall em
           pip install empy #Dependency issue
           
       - name: Cache OpenCV

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Install deps with rosdep
         run: |
+          rosdep init
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
+          pip install empy #Dependency issue
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
+          pip install empy #Dependency issue
           
       - name: Cache OpenCV
         id: opencv-cache
@@ -51,7 +52,6 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
-          pip install empy #Dependency issue
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup ROS2 distro and system deps
-        uses: ros-tooling/setup-ros@v0.2
+        uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: foxy
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,14 @@ jobs:
         run: |
           rosdep update --include-eol
           rosdep install -i --from-path src --rosdistro foxy -y
+
+      - name: Uninstall em package
+        run: |
+          pip uninstall em -y
+
+      - name: Install empy package
+        run: |
+          pip install empy -y
           
           
           
@@ -53,8 +61,6 @@ jobs:
         run: |
           source /opt/ros/foxy/setup.bash
           source /usr/share/gazebo/setup.sh
-          pip uninstall em
-          pip install empy #Dependency issue
           colcon build --cmake-args -DCMAKE_CXX_STANDARD=14
           source ./install/setup.bash
           colcon test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup ROS2 distro and system deps
-        uses: ros-tooling/setup-ros@v0.7
+        uses: ros-tooling/setup-ros@v0.6
         with:
           required-ros-distributions: foxy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Triton AUV
 
-This repository contains the ROS2 system for the UBC SubBots Triton AUV. It is meant be launched in Ubuntu 20.04 on the Jetson TX2 on board the Triton AUV. 
+This repository contains the ROS2 system for the UBC SubBots Triton AUV. It is meant be launched in Ubuntu 20.04 on the Jetson TX2 on board the Triton AUV.
 
 # Contents
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Next, install rosdep as such
  
     sudo apt install python3-rosdep2
     rosdep update
+    rosdep update --include-eol #(Foxy is now at end of life)
   
 Then, from the folder `triton`, resolve any dependency issues using the following command
  

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Source the global ROS2 setup script in the terminal
 Next, install rosdep as such
  
     sudo apt install python3-rosdep2
-    rosdep update
     rosdep update --include-eol #(Foxy is now at end of life)
   
 Then, from the folder `triton`, resolve any dependency issues using the following command

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -1,0 +1,62 @@
+FROM ubuntu:20.04
+
+# Standard updating and installing required packages
+RUN apt-get update -y && \
+    apt-get install -y \
+    build-essential \
+    git \
+    curl \
+    wget \
+    python3 \
+    python3-pip \
+    sudo \
+    software-properties-common \
+    locales \
+    tzdata \
+    xorg \
+    neovim \
+    vim && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Locale setup
+RUN locale-gen en_US en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+
+# ROS2 Installation
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | sudo tee /usr/share/keyrings/ros-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list && \
+    apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y ros-foxy-desktop python3-argcomplete ros-dev-tools ros-foxy-gazebo-ros-pkgs
+
+# Gazebo environment setup
+RUN echo "export GAZEBO_IP=127.0.0.1" >> /etc/bash.bashrc && \
+    echo "export DISPLAY=\$(cat /etc/resolv.conf | grep nameserver | awk '{print \$2}'):0" >> /etc/bash.bashrc && \
+    echo "export LIBGL_ALWAYS_INDIRECT=0" >> /etc/bash.bashrc
+
+# Creating a user
+RUN useradd -m software && \
+    usermod -aG sudo software && \
+    echo 'software ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/software && \
+    echo 'software:password' | chpasswd
+
+USER software
+WORKDIR /home/software
+
+# ROS2 environment setup for the user
+RUN echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
+
+# Custom messages for the user
+RUN echo "echo 'Hello, welcome to Ubuntu 20.04 with ROS2 installed'" >> ~/.bashrc && \
+    echo "echo 'Hashaam Zafar - 2023'" >> ~/.bashrc && \
+    echo "echo 'Contact Hzafar04@student.ubc.ca for any questions.'" >> ~/.bashrc
+
+# Source ROS2 setup.bash at the end
+ENTRYPOINT ["/bin/bash", "-c", "source /opt/ros/foxy/setup.bash && exec bash"]
+
+# Expose ports if needed for ROS2
+EXPOSE 11311
+

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:20.04
-
 # Standard updating and installing required packages
-RUN apt-get update -y && \
-    apt-get install -y \
+RUN  apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     git \
     curl \

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -42,20 +42,5 @@ RUN useradd -m software && \
     echo 'software ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/software && \
     echo 'software:password' | chpasswd
 
-USER software
-WORKDIR /home/software
-
-# ROS2 environment setup for the user
-RUN echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
-
-# Custom messages for the user
-RUN echo "echo 'Hello, welcome to Ubuntu 20.04 with ROS2 installed'" >> ~/.bashrc && \
-    echo "echo 'Hashaam Zafar - 2023'" >> ~/.bashrc && \
-    echo "echo 'Contact Hzafar04@student.ubc.ca for any questions.'" >> ~/.bashrc
-
 # Source ROS2 setup.bash at the end
 ENTRYPOINT ["/bin/bash", "-c", "source /opt/ros/foxy/setup.bash && exec bash"]
-
-# Expose ports if needed for ROS2
-EXPOSE 11311
-


### PR DESCRIPTION
Fixed Workflow testing. 

in our yaml file, we had something called ros-tooling/setup-ros@v0.2 that was a step to install foxy in our testing environment. It had a problem with python packages (empy) that would lead to an instant failure of the run. There is a patch starting ros-tooling/setup-ros@v0.7, however, since our distribution Foxy has reached its end of life, v0.7 is incompatible. To circumvent ros-tooling/setup-ros@v0.2 I ended up using a docker image to replace that step